### PR TITLE
Issue5952 fix smt code paths output

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -258,7 +258,7 @@ void smt2_convt::define_object_size(
         << "((_ extract " << h << " " << l << ") ";
     convert_expr(ptr);
     out << ") (_ bv" << number << " " << config.bv_encoding.object_bits << "))"
-        << "(= " << id << " (_ bv" << *object_size << " " << size_width
+        << "(= |" << id << "| (_ bv" << *object_size << " " << size_width
         << "))))\n";
 
     ++number;
@@ -1931,7 +1931,7 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_object_size)
   {
-    out << object_sizes[expr];
+    out << "|" << object_sizes[expr] << "|";
   }
   else if(expr.id()==ID_let)
   {
@@ -4589,7 +4589,7 @@ void smt2_convt::find_symbols(const exprt &expr)
       {
         const irep_idt id =
           "object_size." + std::to_string(object_sizes.size());
-        out << "(declare-fun " << id << " () ";
+        out << "(declare-fun |" << id << "| () ";
         convert_type(expr.type());
         out << ")" << "\n";
 

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -190,7 +190,8 @@ protected:
   void convert_address_of_rec(
     const exprt &expr, const pointer_typet &result_type);
 
-  void define_object_size(const irep_idt &id, const exprt &expr);
+  void
+  define_object_size(const irep_idt &id, const exprt &expr, std::ostream &os);
 
   // keeps track of all non-Boolean symbols and their value
   struct identifiert


### PR DESCRIPTION
This PR fixes a few issues related to the SMT backend and object_size:

1. The object_size identifiers are now correctly escaped when emitted in SMT2 formats
2. Object_size assertions are now emitted to temporary files, this code path did not emit them properly causing incorrect results for SMT object_size checks

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
