### PR TITLE
smt2 stream consistency

### DIFF
--- a/regression/cbmc/Malloc6/test.desc
+++ b/regression/cbmc/Malloc6/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer1/test.desc
+++ b/regression/cbmc/Pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer28/test.desc
+++ b/regression/cbmc/Pointer28/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --little-endian
 ^EXIT=0$

--- a/regression/cbmc/Pointer4/test.desc
+++ b/regression/cbmc/Pointer4/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/String8/test.desc
+++ b/regression/cbmc/String8/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction7/test.desc
+++ b/regression/cbmc/String_Abstraction7/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --string-abstraction --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/address_space_size_limit3/test.desc
+++ b/regression/cbmc/address_space_size_limit3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.i
 --32 --little-endian --object-bits 25 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/null7/test.desc
+++ b/regression/cbmc/null7/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/struct7/test.desc
+++ b/regression/cbmc/struct7/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/void_pointer2/test.desc
+++ b/regression/cbmc/void_pointer2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --no-simplify --unwind 3
 ^EXIT=0$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -176,9 +176,9 @@ void smt2_convt::write_header()
     out << "(set-logic " << logic << ")" << "\n";
 }
 
-void smt2_convt::write_footer(std::ostream &os)
+void smt2_convt::write_footer()
 {
-  os << "\n";
+  out << "\n";
 
   // fix up the object sizes
   for(const auto &object : object_sizes)
@@ -186,45 +186,45 @@ void smt2_convt::write_footer(std::ostream &os)
 
   if(use_check_sat_assuming && !assumptions.empty())
   {
-    os << "(check-sat-assuming (";
+    out << "(check-sat-assuming (";
     for(const auto &assumption : assumptions)
       convert_literal(to_literal_expr(assumption).get_literal());
-    os << "))\n";
+    out << "))\n";
   }
   else
   {
     // add the assumptions, if any
     if(!assumptions.empty())
     {
-      os << "; assumptions\n";
+      out << "; assumptions\n";
 
       for(const auto &assumption : assumptions)
       {
-        os << "(assert ";
+        out << "(assert ";
         convert_literal(to_literal_expr(assumption).get_literal());
-        os << ")"
-           << "\n";
+        out << ")"
+            << "\n";
       }
     }
 
-    os << "(check-sat)\n";
+    out << "(check-sat)\n";
   }
 
-  os << "\n";
+  out << "\n";
 
   if(solver!=solvert::BOOLECTOR)
   {
     for(const auto &id : smt2_identifiers)
-      os << "(get-value (|" << id << "|))"
-         << "\n";
+      out << "(get-value (|" << id << "|))"
+          << "\n";
   }
 
-  os << "\n";
+  out << "\n";
 
-  os << "(exit)\n";
+  out << "(exit)\n";
 
-  os << "; end of SMT2 file"
-     << "\n";
+  out << "; end of SMT2 file"
+      << "\n";
 }
 
 void smt2_convt::define_object_size(
@@ -267,7 +267,7 @@ void smt2_convt::define_object_size(
 
 decision_proceduret::resultt smt2_convt::dec_solve()
 {
-  write_footer(out);
+  write_footer();
   out.flush();
   return decision_proceduret::resultt::D_ERROR;
 }

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -96,7 +96,7 @@ protected:
   resultt dec_solve() override;
 
   void write_header();
-  void write_footer(std::ostream &);
+  void write_footer();
 
   // tweaks for arrays
   bool use_array_theory(const exprt &);

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -126,7 +126,7 @@ protected:
   void convert_with(const with_exprt &expr);
   void convert_update(const exprt &expr);
 
-  std::string convert_identifier(const irep_idt &identifier);
+  static std::string convert_identifier(const irep_idt &identifier);
 
   void convert_expr(const exprt &);
   void convert_type(const typet &);

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -34,18 +34,20 @@ std::string smt2_dect::decision_procedure_text() const
 decision_proceduret::resultt smt2_dect::dec_solve()
 {
   ++number_of_solver_calls;
-  write_footer();
 
   temporary_filet temp_file_problem("smt2_dec_problem_", ""),
     temp_file_stdout("smt2_dec_stdout_", ""),
     temp_file_stderr("smt2_dec_stderr_", "");
 
-  {
-    // we write the problem into a file
-    std::ofstream problem_out(
-      temp_file_problem(), std::ios_base::out | std::ios_base::trunc);
-    problem_out << stringstream.str();
-  }
+  const auto write_problem_to_file = [&](std::ofstream problem_out) {
+    cached_output << stringstream.str();
+    stringstream.clear();
+    write_footer();
+    problem_out << cached_output.str() << stringstream.str();
+    stringstream.clear();
+  };
+  write_problem_to_file(std::ofstream(
+    temp_file_problem(), std::ios_base::out | std::ios_base::trunc));
 
   std::vector<std::string> argv;
   std::string stdin_filename;

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -41,10 +41,10 @@ decision_proceduret::resultt smt2_dect::dec_solve()
 
   const auto write_problem_to_file = [&](std::ofstream problem_out) {
     cached_output << stringstream.str();
-    stringstream.clear();
+    stringstream.str(std::string{});
     write_footer();
     problem_out << cached_output.str() << stringstream.str();
-    stringstream.clear();
+    stringstream.str(std::string{});
   };
   write_problem_to_file(std::ofstream(
     temp_file_problem(), std::ios_base::out | std::ios_base::trunc));

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -34,6 +34,7 @@ std::string smt2_dect::decision_procedure_text() const
 decision_proceduret::resultt smt2_dect::dec_solve()
 {
   ++number_of_solver_calls;
+  write_footer();
 
   temporary_filet temp_file_problem("smt2_dec_problem_", ""),
     temp_file_stdout("smt2_dec_stdout_", ""),
@@ -44,7 +45,6 @@ decision_proceduret::resultt smt2_dect::dec_solve()
     std::ofstream problem_out(
       temp_file_problem(), std::ios_base::out | std::ios_base::trunc);
     problem_out << stringstream.str();
-    write_footer(problem_out);
   }
 
   std::vector<std::string> argv;

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -45,6 +45,10 @@ public:
 protected:
   message_handlert &message_handler;
 
+  /// Everything except the footer is cached, so that output files can be
+  /// rewritten with varying footers.
+  std::stringstream cached_output;
+
   resultt read_result(std::istream &in);
 };
 


### PR DESCRIPTION
This avoids bugs arising from some of the member functions of
`smt2::convt` writing to `os` and some of the them writing to `out`.
This was causing some of the generated text to be written out when using
`--outfile`, but not without this argument, in the case where cbmc uses
a temp file to send the formula to the solver itself.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
