### PR TITLE
Smt2 object size

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -258,7 +258,7 @@ void smt2_convt::define_object_size(
         << "((_ extract " << h << " " << l << ") ";
     convert_expr(ptr);
     out << ") (_ bv" << number << " " << config.bv_encoding.object_bits << "))"
-        << "(= " << id << " (_ bv" << *object_size << " " << size_width
+        << "(= |" << id << "| (_ bv" << *object_size << " " << size_width
         << "))))\n";
 
     ++number;
@@ -1931,7 +1931,7 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_object_size)
   {
-    out << object_sizes[expr];
+    out << "|" << object_sizes[expr] << "|";
   }
   else if(expr.id()==ID_let)
   {
@@ -4589,7 +4589,7 @@ void smt2_convt::find_symbols(const exprt &expr)
       {
         const irep_idt id =
           "object_size." + std::to_string(object_sizes.size());
-        out << "(declare-fun " << id << " () ";
+        out << "(declare-fun |" << id << "| () ";
         convert_type(expr.type());
         out << ")" << "\n";
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -176,9 +176,9 @@ void smt2_convt::write_header()
     out << "(set-logic " << logic << ")" << "\n";
 }
 
-void smt2_convt::write_footer(std::ostream &os)
+void smt2_convt::write_footer()
 {
-  os << "\n";
+  out << "\n";
 
   // fix up the object sizes
   for(const auto &object : object_sizes)
@@ -186,45 +186,45 @@ void smt2_convt::write_footer(std::ostream &os)
 
   if(use_check_sat_assuming && !assumptions.empty())
   {
-    os << "(check-sat-assuming (";
+    out << "(check-sat-assuming (";
     for(const auto &assumption : assumptions)
       convert_literal(to_literal_expr(assumption).get_literal());
-    os << "))\n";
+    out << "))\n";
   }
   else
   {
     // add the assumptions, if any
     if(!assumptions.empty())
     {
-      os << "; assumptions\n";
+      out << "; assumptions\n";
 
       for(const auto &assumption : assumptions)
       {
-        os << "(assert ";
+        out << "(assert ";
         convert_literal(to_literal_expr(assumption).get_literal());
-        os << ")"
-           << "\n";
+        out << ")"
+            << "\n";
       }
     }
 
-    os << "(check-sat)\n";
+    out << "(check-sat)\n";
   }
 
-  os << "\n";
+  out << "\n";
 
   if(solver!=solvert::BOOLECTOR)
   {
     for(const auto &id : smt2_identifiers)
-      os << "(get-value (|" << id << "|))"
-         << "\n";
+      out << "(get-value (|" << id << "|))"
+          << "\n";
   }
 
-  os << "\n";
+  out << "\n";
 
-  os << "(exit)\n";
+  out << "(exit)\n";
 
-  os << "; end of SMT2 file"
-     << "\n";
+  out << "; end of SMT2 file"
+      << "\n";
 }
 
 void smt2_convt::define_object_size(
@@ -267,7 +267,7 @@ void smt2_convt::define_object_size(
 
 decision_proceduret::resultt smt2_convt::dec_solve()
 {
-  write_footer(out);
+  write_footer();
   out.flush();
   return decision_proceduret::resultt::D_ERROR;
 }

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -96,7 +96,7 @@ protected:
   resultt dec_solve() override;
 
   void write_header();
-  void write_footer(std::ostream &);
+  void write_footer();
 
   // tweaks for arrays
   bool use_array_theory(const exprt &);

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -126,7 +126,7 @@ protected:
   void convert_with(const with_exprt &expr);
   void convert_update(const exprt &expr);
 
-  std::string convert_identifier(const irep_idt &identifier);
+  static std::string convert_identifier(const irep_idt &identifier);
 
   void convert_expr(const exprt &);
   void convert_type(const typet &);

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -40,11 +40,12 @@ decision_proceduret::resultt smt2_dect::dec_solve()
     temp_file_stderr("smt2_dec_stderr_", "");
 
   {
+    write_footer();
+
     // we write the problem into a file
     std::ofstream problem_out(
       temp_file_problem(), std::ios_base::out | std::ios_base::trunc);
     problem_out << stringstream.str();
-    write_footer(problem_out);
   }
 
   std::vector<std::string> argv;


### PR DESCRIPTION
This PR includes @thomasspriggs PR #17 and also fixes the object size identifiers not being escaped in SMT2 output.

Also (re)created to test CI.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
