### PR TITLE
Light smt object size write once

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -254,7 +254,7 @@ void smt2_convt::define_object_size(
         << "((_ extract " << h << " " << l << ") ";
     convert_expr(ptr);
     out << ") (_ bv" << number << " " << config.bv_encoding.object_bits << "))"
-        << "(= " << id << " (_ bv" << *object_size << " " << size_width
+        << "(= |" << id << "| (_ bv" << *object_size << " " << size_width
         << "))))\n";
 
     ++number;
@@ -1938,7 +1938,7 @@ void smt2_convt::convert_expr(const exprt &expr)
   }
   else if(expr.id()==ID_object_size)
   {
-    out << object_sizes[expr];
+    out << "|" << object_sizes[expr] << "|";
   }
   else if(expr.id()==ID_let)
   {
@@ -4596,7 +4596,7 @@ void smt2_convt::find_symbols(const exprt &expr)
       {
         const irep_idt id =
           "object_size." + std::to_string(object_sizes.size());
-        out << "(declare-fun " << id << " () ";
+        out << "(declare-fun |" << id << "| () ";
         convert_type(expr.type());
         out << ")" << "\n";
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -114,7 +114,7 @@ smt2_convt::smt2_convt(
     use_datatypes = true;
     break;
   }
-
+  object_sizes_written = false;
   write_header();
 }
 
@@ -179,10 +179,6 @@ void smt2_convt::write_header()
 void smt2_convt::write_footer(std::ostream &os)
 {
   os << "\n";
-
-  // fix up the object sizes
-  for(const auto &object : object_sizes)
-    define_object_size(object.second, object.first);
 
   if(use_check_sat_assuming && !assumptions.empty())
   {
@@ -265,8 +261,19 @@ void smt2_convt::define_object_size(
   }
 }
 
+void smt2_convt::write_object_sizes()
+{
+  if(object_sizes_written)
+    return;
+  object_sizes_written = true;
+  // fix up the object sizes
+  for(const auto &object : object_sizes)
+    define_object_size(object.second, object.first);
+}
+
 decision_proceduret::resultt smt2_convt::dec_solve()
 {
+  write_object_sizes();
   write_footer(out);
   out.flush();
   return decision_proceduret::resultt::D_ERROR;

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -126,7 +126,7 @@ protected:
   void convert_with(const with_exprt &expr);
   void convert_update(const exprt &expr);
 
-  std::string convert_identifier(const irep_idt &identifier);
+  static std::string convert_identifier(const irep_idt &identifier);
 
   void convert_expr(const exprt &);
   void convert_type(const typet &);

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -191,6 +191,7 @@ protected:
     const exprt &expr, const pointer_typet &result_type);
 
   void define_object_size(const irep_idt &id, const exprt &expr);
+  void write_object_sizes();
 
   // keeps track of all non-Boolean symbols and their value
   struct identifiert
@@ -227,6 +228,7 @@ protected:
   defined_expressionst defined_expressions;
 
   defined_expressionst object_sizes;
+  bool object_sizes_written;
 
   typedef std::set<std::string> smt2_identifierst;
   smt2_identifierst smt2_identifiers;

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -40,6 +40,7 @@ decision_proceduret::resultt smt2_dect::dec_solve()
     temp_file_stderr("smt2_dec_stderr_", "");
 
   {
+    write_object_sizes();
     // we write the problem into a file
     std::ofstream problem_out(
       temp_file_problem(), std::ios_base::out | std::ios_base::trunc);


### PR DESCRIPTION
This PR fixes [CBMC Issue #5952](https://github.com/diffblue/cbmc/issues/5952) and also makes some minor fixes.

The main fix is to the problem of outputting the object sizes. These were originally called to be output in the `write_footer`, but also output to the common ostream that had (in the internal code path where `cbmc` calls the solver directly) already been written, thus not writing them to the temporary file. The fix here handles the output of the object sizes to be separate and output once to the common ostream before writing it (and no longer relying on the `write_footer` code.

Small fixes includes:

1. correctly quote object size identifiers in the SMT2 output
2. define `convert_identifier` to be static

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
