### PR TITLE
Fixes array value in traces for Z3 SMT

### DIFF
--- a/regression/cbmc/enum-trace1/test_json.desc
+++ b/regression/cbmc/enum-trace1/test_json.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --json-ui --function test --trace
 activate-multi-line-match

--- a/regression/cbmc/json-interface1/test.desc
+++ b/regression/cbmc/json-interface1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 --json-interface
 < test.json
 activate-multi-line-match

--- a/regression/cbmc/json1/test.desc
+++ b/regression/cbmc/json1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --json-ui --stop-on-fail
 activate-multi-line-match

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -151,6 +151,10 @@ protected:
   exprt parse_union(const irept &s, const union_typet &type);
   exprt parse_array(const irept &s, const array_typet &type);
   exprt parse_rec(const irept &s, const typet &type);
+  void walk_array_tree(
+    std::unordered_map<size_t, exprt> *operands_map,
+    const irept &src,
+    const array_typet &type);
 
   // we use this to build a bit-vector encoding of the FPA theory
   void convert_floatbv(const exprt &expr);


### PR DESCRIPTION
This is a fix for how we parse Z3 array output to reconstruct
values in traces. This is known to be incomplete at this stage
and NOT working for solvers apart from Z3.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
